### PR TITLE
Use customized data_generation_base_dir

### DIFF
--- a/scripts/setup-tpch-db
+++ b/scripts/setup-tpch-db
@@ -197,6 +197,10 @@ while [[ $# > 0 ]]; do
 	-D|--data-gen-dir|--data-generation-directory|--data-generation-dir|--gen-dir|--data-gen-directory)
 		raw_data_generation_dir="$2"
 		data_generation_dir="$(readlink -f $raw_data_generation_dir)"
+		data_generation_base_dir=${data_generation_dir}
+		while [ ! -d ${data_generation_base_dir} ]; do
+			data_generation_base_dir=$(dirname ${data_generation_base_dir})
+		done
 		shift # past argument
 		;;
 	-k|--keep-raw-tables|--keep-raw)


### PR DESCRIPTION
https://github.com/eyalroz/tpch-tools/pull/2 didn't really fix the problem so I just deleted the check function and closed the pull request.

If we use `-D` option, `data_generation_base_dir` didn't change accordingly. In this commit it searches for the closest parent to keep `gb_available_space_for_dir ` working properly.